### PR TITLE
str_replace() argument 2 only accepts array|string

### DIFF
--- a/inc/plugins/dvz_hash/core.php
+++ b/inc/plugins/dvz_hash/core.php
@@ -191,7 +191,7 @@ function getKnownAlgorithms(bool $includeWrappable = true): array
             }
         );
 
-        $algorithms = str_replace('.php', null, $filenames);
+        $algorithms = str_replace('.php', '', $filenames);
     }
 
     return $algorithms;


### PR DESCRIPTION
I think this issue is related to a PHP8 change but I couldn't find the references to it.

This warning stops users from login in to both the front and back end.

PHP Version: 8.2.11